### PR TITLE
BUGFIX: avoid erroring when images are not present

### DIFF
--- a/lib/ueberauth/strategy/spotify.ex
+++ b/lib/ueberauth/strategy/spotify.ex
@@ -85,7 +85,7 @@ defmodule Ueberauth.Strategy.Spotify do
     %Info{
       name: user["display_name"],
       email: user["email"],
-      image: user["images"] |> List.first |> Map.get("url"),
+      image: user["images"] |> List.first || %{url: nil} |> Map.get("url"),
       urls: user["external_urls"]
     }
   end


### PR DESCRIPTION
Resolves #4 